### PR TITLE
Create GitHub Actions for automatic and manual triggering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'master'
+      release_name:
+        description: 'Name of the release'
+        required: true
+        default: 'Test Release'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [x86_64, ARM64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.os }}-${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}
+          path: target/release/my_project
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.event.inputs.release_name || 'Release ' + github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ matrix.os }}-${{ matrix.arch }}
+          asset_name: ${{ matrix.os }}-${{ matrix.arch }}.zip
+          asset_content_type: application/zip
+


### PR DESCRIPTION
###  Workflow Triggers

This create introduces changes to our GitHub Actions configuration to support both automatic and manual triggering of the build and release processes:

**Key Changes:**
- **Automatic Triggering:** The workflow is now configured to automatically trigger a build and release process whenever a tag matching the 'v*' pattern is pushed.
- **Manual Triggering:** Added a `workflow_dispatch` option that allows manual triggering of the workflow from the GitHub UI. This feature includes input fields for specifying the branch and the name of the release, providing flexibility for deployment and testing.

**Benefits:**
- **Flexibility:** Developers can now initiate a build manually from any branch, allowing for more controlled and custom deployments.
- **Automation:** Continues to support automatic deployment when new versions are tagged, streamlining the release process.

This dual approach ensures that our CI/CD pipeline remains robust, flexible, and aligned with our development practices. It also helps in maintaining a clear separation between development and production builds, enhancing our overall project management.
